### PR TITLE
Fix new instance creation with userdata

### DIFF
--- a/cloud/openstack/os_server.py
+++ b/cloud/openstack/os_server.py
@@ -423,7 +423,9 @@ def main():
             )
 
     try:
-        cloud = shade.openstack_cloud(**module.params)
+        cloud_params = dict(module.params)
+        cloud_params.pop('userdata', None)
+        cloud = shade.openstack_cloud(**cloud_params)
 
         if state == 'present':
             _get_server_state(module, cloud)


### PR DESCRIPTION
When trying to create an instance with the following userdata:

```
#cloud-config
password: passw0rd
chpasswd: { expire: False }
ssh_pwauth: True.
```

I was getting the following error:

```
Traceback (most recent call last):
  File "/Users/daz/.ansible/tmp/ansible-tmp-1427796231.01-271559653773869/os_server", line 2145, in <module>
    main()
  File "/Users/daz/.ansible/tmp/ansible-tmp-1427796231.01-271559653773869/os_server", line 429, in main
    cloud = shade.openstack_cloud(**module.params)
  File "/Users/daz/.virtualenvs/venv/lib/python2.7/site-packages/shade/__init__.py", line 75, in openstack_cloud
    **kwargs)
  File "/Users/daz/.virtualenvs/venv/lib/python2.7/site-packages/os_client_config/config.py", line 349, in get_one_cloud
    config[key] = value.format(**config)
KeyError: ' expire'
```

I'm not sure why os-client-config is trying to grok my user data, but regardless this just strips it out of the `openstack_cloud` call.
